### PR TITLE
Remove ROM calls

### DIFF
--- a/joystick.asm
+++ b/joystick.asm
@@ -1,0 +1,46 @@
+; Joystick handling
+
+; This routine reads all four joystick axes. It bails out as soon as it
+; gets two identical reads in a row or after JOYATTEMPT tries. This clobbers
+; A, B, and X. If it doesn't get two identical reads in a row, the value
+; on the last read is used.
+;
+; This varies from the GETJOY routine in the ROM as follows:
+; * it uses PSHS and PULS
+; * it doesn't clobber U if SETMUX is not pointing to the ROM routine
+; * it will bail out as soon as it gets two identical reads in a row. The ROM
+;   routine will try 10 times to get a read that matches the result from the
+;   *last call* to GETJOY. That means if the joystick moved, it will always do
+;   all 10 reads.
+JOYATTEMPT      equ 10          ; number of times to try reading an axis
+GETJOY          jsr SNDOFF      ; turn off sound (we mess with the MUX here)
+                ldx #POTVAL+4   ; point to the end of the axis data
+                ldb #3          ; there are four axes to read - 3 is highest axis number
+GETJOY0         lda #JOYATTEMPT ; get retry count
+                pshs d          ; save retry count and axis number
+                jsr SETMUX      ; select the desired axis
+GETJOY1         ldd #0x4080     ; initialize trial result and bit value to add/subtract
+GETJOY2         pshs a          ; save bit value
+                orb #2          ; set RS232 to marking
+                stb PIA1.DA     ; set DAC output to trival value
+                eorb #2         ; reset RS232 bit
+                lda PIA0.DA     ; get comparator value
+                bmi GETJOY3     ; brif axis value is higher than trial value
+                subb ,s         ; subtract bit value from trial value
+                bra GETJOY4
+GETJOY3         addb ,s         ; add bit value to the trial value
+GETJOY4         puls a          ; get back bit value
+                lsra            ; shift bit value down one
+                cmpa #1         ; done all bits?
+                bne GETJOY2     ; brif not
+                lsrb            ; normalize value into low 6 bits
+                lsrb
+                cmpb -1,x       ; did it match the last read?
+                beq GETJOY5     ; brif so - we're done with this axis
+                stb -1,x        ; save this value
+                dec ,s          ; have we done all retries?
+                bne GETJOY1     ; brif not - try again
+GETJOY5         puls d          ; get back attempt counter and axis number
+                decb            ; done all axes?
+                bpl GETJOY0     ; brif not - do next one
+                rts

--- a/main.asm
+++ b/main.asm
@@ -10,9 +10,6 @@
 ; 1C00		explosion sprite queue
 
 JOYIN	equ $a00a
-SETMUX	equ $a9a2
-SNDOFF	equ $a974
-SNDON	equ $a976
 
 PIA0.DA	equ $ff00
 PIA0.CA	equ $ff01
@@ -126,7 +123,8 @@ plr2creatures	equ $1fa0	; where the creatures really are for player two
 START	orcc #$50			; make sure interrupts are disabled
 	clr $ff40			; make sure all FDC drive motors and selects are off
 	lbra LCD46			; launch main initialization sequence
-
+; fetch in various source files
+                include sound.asm                               ; fetch sound handling routines
 ; Render the vertical lines of the map
 drawvert	leau LC34A,pcr		; point to short circuit offset table for vertical lines
 	ldd mazeoffx			; fetch screen display offset for maze

--- a/main.asm
+++ b/main.asm
@@ -9,8 +9,6 @@
 ; 1000-1BFF	graphics screen #2
 ; 1C00		explosion sprite queue
 
-JOYIN	equ $a00a
-
 PIA0.DA	equ $ff00
 PIA0.CA	equ $ff01
 PIA0.DB	equ $ff02
@@ -125,6 +123,7 @@ START	orcc #$50			; make sure interrupts are disabled
 	lbra LCD46			; launch main initialization sequence
 ; fetch in various source files
                 include sound.asm                               ; fetch sound handling routines
+                include joystick.asm                            ; fetch joystick handling routines
 ; Render the vertical lines of the map
 drawvert	leau LC34A,pcr		; point to short circuit offset table for vertical lines
 	ldd mazeoffx			; fetch screen display offset for maze
@@ -1680,7 +1679,7 @@ LD072	ldb PIA0.DA		; read keyboard rows/buttons
 	eorb #3			; set nonzero if pressed
 	bne LD072		; brif button pressed - we're waiting until the button is released
 	clr numplayers		; set to no players
-LD07D	jsr [JOYIN]		; read joysticks
+LD07D	jsr GETJOY		; read joysticks
 	lda POTVAL+2		; get X coordinate for first player
 	cmpa #$20		; is it to the left?
 	bgt LD09B		; brif not
@@ -1860,7 +1859,7 @@ LD1BE	lbsr swaprender		; switch screens
 * ADJUST PLAYER POSITION
 * VC1 VC3 VC4 VC5
 LD1FF	;jsr SNDOFF		; turn off sound
-	jsr [JOYIN]		; read joysticks
+	jsr GETJOY		; read joysticks
 	ldb curplayer		; get current player number
 	asrb			; set to 0 for player 2, 2 for player 1
 	lslb

--- a/sound.asm
+++ b/sound.asm
@@ -1,0 +1,33 @@
+; Sound handling routines.
+;
+; Enable the the MUX (turn sound on). Bit 3 of FF23 controls
+; whether the sound output is enabled or not.
+SNDON           lda PIA1.CB     ; get current PIA control state
+                ora #8          ; set MUX enable bit
+                sta PIA1.CB     ; set new state
+                rts
+; Disable the MUX (turn sound off)
+SNDOFF          lda PIA1.CB     ; get current PIA control state
+                anda #0xf7      ; turn off MUX enable bit
+                sta PIA1.CB     ; set new state
+                rts
+; Set MUX (DAC destination and sound source); enter with the
+; desired source in B. The MUX is set using bit 3 of FF01
+; and bit 3 of FF03 with FF01 holding the LSB. This version is
+; much longer than the version in the Color Basic ROM but it has
+; the advantage that it doesn't clobber U and it should run slightly
+; faster by virtue of using extended direct addressing instead of
+; indexed addressing and it doesn't have an extra BSR.
+SETMUX          lda PIA0.CA     ; get PIA control for bit 0
+                anda #0xf7      ; clear the MUX bit
+                lsrb            ; is this bit set?
+                bcc SETMUX0     ; brif not
+                ora #8          ; enable this bit in the MUX
+SETMUX0         sta PIA0.CA     ; save new selection bit 0
+                lda PIA0.CB     ; get PIA control for bit 1
+                anda #0xf7      ; clear the MUX bit
+                lsrb            ; is this bit set?
+                bcc SETMUX1     ; brif not
+                ora #8          ; enable this bit in the MUX
+SETMUX1         sta PIA0.CB     ; set new selection bit 1
+                rts


### PR DESCRIPTION
Here's a pull request that should remove the ROM calls for SNDON, SNDOFF, SETMUX, and JOYIN. I think that's all the ROM calls.

I haven't tested the joystick code but unless I made a typo, it should work. It's basically the ROM code with a couple of modifications.

You'll note I added these bits of code in separate files. I think my text editor converts tabs to spaces so apologies if that offends your coding style. :)